### PR TITLE
Add src to files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "country-vat",
   "description": "Get a country VAT rate. ISO 3166-1 compliant.",
   "homepage": "https://nicedoc.io/Kikobeats/country-vat",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "src/index.js",
   "author": {
     "email": "josefrancisco.verdu@gmail.com",
@@ -63,6 +63,7 @@
     "node": ">= 12"
   },
   "files": [
+    "src",
     "index.json",
     "scripts"
   ],


### PR DESCRIPTION
Hello!

Love the library, very helpful. It looks like this does not work properly in situations where the package manager enforces the `files` directive in package.json. Currently it's missing `src` so the `rates.json` file is missing. This fixes the issue!

Thank you!